### PR TITLE
fix: set the default value of the `minimumSupportedVersion` parameter…

### DIFF
--- a/sqlcipher/src/androidTest/java/net/zetetic/database/sqlcipher_cts/SupportHelperTest.java
+++ b/sqlcipher/src/androidTest/java/net/zetetic/database/sqlcipher_cts/SupportHelperTest.java
@@ -48,7 +48,7 @@ public class SupportHelperTest {
     }
 
     @Test
-    public void shouldRunUpgradeFromVersion1ToVersion2() {
+    public void shouldRunUpgradeFromVersion1ToVersion2WhenMinSupportedVersionIsProvided() {
         FakeCallback initialCallback = new FakeCallback(1);
 
         SupportHelper initialHelper = new SupportHelper(createConfiguration(initialCallback), null, null, true);
@@ -63,6 +63,29 @@ public class SupportHelperTest {
 
         // minSupportedVersion = 1
         SupportHelper helper = new SupportHelper(createConfiguration(callbackWrapper), null, null, true, 1);
+
+        helper.getWritableDatabase();
+        helper.close();
+
+        assertEquals(0, callbackWrapper.callbackCount[CREATION_INDEX]);
+        assertEquals(1, callbackWrapper.callbackCount[UPGRADE_INDEX]);
+    }
+
+    @Test
+    public void shouldRunUpgradeFromVersion1ToVersion2() {
+        FakeCallback initialCallback = new FakeCallback(1);
+
+        SupportHelper initialHelper = new SupportHelper(createConfiguration(initialCallback), null, null, true);
+
+        initialHelper.getWritableDatabase();
+        initialHelper.close();
+
+        assertEquals(1, initialCallback.callbackCount[CREATION_INDEX]);
+        assertEquals(0, initialCallback.callbackCount[UPGRADE_INDEX]);
+
+        FakeCallback callbackWrapper = new FakeCallback(2);
+
+        SupportHelper helper = new SupportHelper(createConfiguration(callbackWrapper), null, null, true);
 
         helper.getWritableDatabase();
         helper.close();

--- a/sqlcipher/src/main/java/net/zetetic/database/sqlcipher/SupportHelper.java
+++ b/sqlcipher/src/main/java/net/zetetic/database/sqlcipher/SupportHelper.java
@@ -10,7 +10,7 @@ public class SupportHelper implements SupportSQLiteOpenHelper {
 
   public SupportHelper(final Configuration configuration, byte[] password, SQLiteDatabaseHook hook,
                        boolean enableWriteAheadLogging) {
-    this(configuration, password, hook, enableWriteAheadLogging, configuration.callback.version);
+    this(configuration, password, hook, enableWriteAheadLogging, 0);
   }
 
   public SupportHelper(final Configuration configuration, byte[] password, SQLiteDatabaseHook hook,


### PR DESCRIPTION
Fix for the issue [13](https://github.com/sqlcipher/sqlcipher-android/issues/13).