### PR TITLE
Throw a specific exception for SQLITE_NOTADB.

### DIFF
--- a/sqlcipher/src/main/java/net/zetetic/database/sqlcipher/SQLiteNotADatabaseException.java
+++ b/sqlcipher/src/main/java/net/zetetic/database/sqlcipher/SQLiteNotADatabaseException.java
@@ -1,0 +1,22 @@
+package net.zetetic.database.sqlcipher;
+
+import android.database.sqlite.SQLiteException;
+
+/**
+ * An exception that is specific to the "SQLITE_NOTADB" error code.
+ *
+ * <a href="https://www.sqlite.org/rescode.html#notadb">SQLITE_NOTADB</a>
+ */
+class SQLiteNotADatabaseException extends SQLiteException {
+   public SQLiteNotADatabaseException() {
+      super();
+   }
+
+   public SQLiteNotADatabaseException(String error) {
+      super(error);
+   }
+
+   public SQLiteNotADatabaseException(String error, Throwable cause) {
+      super(error, cause);
+   }
+}

--- a/sqlcipher/src/main/jni/sqlcipher/android_database_SQLiteCommon.cpp
+++ b/sqlcipher/src/main/jni/sqlcipher/android_database_SQLiteCommon.cpp
@@ -74,7 +74,7 @@ void throw_sqlite3_exception(JNIEnv* env, int errcode,
             /* Upstream treats treat "unsupported file format" error as corruption (SQLiteDatabaseCorruptException).
                However, SQLITE_NOTADB can occur with mismatched keys, which is not a corruption case, so SQLCipher
                treats this as a general exception */
-            exceptionClass = "android/database/sqlite/SQLiteException";
+            exceptionClass = "net/zetetic/database/sqlcipher/SQLiteNotADatabaseException";
             break;
         case SQLITE_CONSTRAINT:
             exceptionClass = "android/database/sqlite/SQLiteConstraintException";


### PR DESCRIPTION
This change throws a specific exception for the SQLITE_NOTADB error case. This should be a non-breaking change, as the exception class extends `SQLiteException`, which is what was being thrown before.