### PR TITLE
Provide exception that indicated database corruption.

### DIFF
--- a/sqlcipher/src/androidTest/java/net/zetetic/database/sqlcipher_android/DatabaseGeneralTest.java
+++ b/sqlcipher/src/androidTest/java/net/zetetic/database/sqlcipher_android/DatabaseGeneralTest.java
@@ -960,7 +960,7 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
         assertFalse(mDatabase.isOpen());
         assertTrue(dbfile.exists());
         try {
-            errorHandler.onCorruption(mDatabase);
+            errorHandler.onCorruption(mDatabase, new SQLiteException());
             if(SQLiteDatabase.hasCodec()){
                 assertTrue(dbfile.exists());
             } else {
@@ -976,7 +976,7 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
         memoryDb.close();
         assertFalse(memoryDb.isOpen());
         try {
-            errorHandler.onCorruption(memoryDb);
+            errorHandler.onCorruption(memoryDb, new SQLiteException());
         } catch (Exception e) {
             fail("unexpected");
         }
@@ -987,7 +987,7 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
         assertNotNull(dbObj);
         assertTrue(dbObj.isOpen());
         try {
-            errorHandler.onCorruption(dbObj);
+            errorHandler.onCorruption(dbObj, new SQLiteException());
             if(SQLiteDatabase.hasCodec()){
                 assertTrue(dbfile.exists());
             } else{
@@ -1012,7 +1012,7 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
         assertTrue(dbObj.isOpen());
         List<Pair<String, String>> attachedDbs = dbObj.getAttachedDbs();
         try {
-            errorHandler.onCorruption(dbObj);
+            errorHandler.onCorruption(dbObj, new SQLiteException());
             if(SQLiteDatabase.hasCodec()){
                 assertTrue(dbfile.exists());
             } else {
@@ -1047,7 +1047,7 @@ public class DatabaseGeneralTest extends AndroidTestCase implements PerformanceT
         assertTrue(dbObj.isOpen());
         attachedDbs = dbObj.getAttachedDbs();
         try {
-            errorHandler.onCorruption(dbObj);
+            errorHandler.onCorruption(dbObj, new SQLiteException());
             if(SQLiteDatabase.hasCodec()){
                 assertTrue(dbfile.exists());
             } else {

--- a/sqlcipher/src/androidTest/java/net/zetetic/database/sqlcipher_cts/SQLCipherOpenHelperTest.java
+++ b/sqlcipher/src/androidTest/java/net/zetetic/database/sqlcipher_cts/SQLCipherOpenHelperTest.java
@@ -72,7 +72,7 @@ public class SQLCipherOpenHelperTest extends AndroidSQLCipherTestCase {
     private final String TAG = getClass().getSimpleName();
 
     public SqlCipherOpenHelper(Context context) {
-      super(context, "test.db", "test", null, 1, 1, sqLiteDatabase -> Log.e(SQLCipherOpenHelperTest.this.TAG, "onCorruption()"), new SQLiteDatabaseHook() {
+      super(context, "test.db", "test", null, 1, 1, (sqLiteDatabase, ex) -> Log.e(SQLCipherOpenHelperTest.this.TAG, "onCorruption()"), new SQLiteDatabaseHook() {
         @Override
         public void preKey(SQLiteConnection sqLiteConnection) {
           Log.d(SQLCipherOpenHelperTest.this.TAG, "preKey()");

--- a/sqlcipher/src/main/java/net/zetetic/database/DatabaseErrorHandler.java
+++ b/sqlcipher/src/main/java/net/zetetic/database/DatabaseErrorHandler.java
@@ -21,6 +21,8 @@
 
 package net.zetetic.database;
 
+import android.database.sqlite.SQLiteException;
+
 import net.zetetic.database.sqlcipher.SQLiteDatabase;
 
 /**
@@ -32,6 +34,7 @@ public interface DatabaseErrorHandler {
      * The method invoked when database corruption is detected.
      * @param dbObj the {@link SQLiteDatabase} object representing the database on which corruption
      * is detected.
+     * @param exception the exception reported by sqlite that indicated the database was corrupted.
      */
-    void onCorruption(SQLiteDatabase dbObj);
+    void onCorruption(SQLiteDatabase dbObj, SQLiteException exception);
 }

--- a/sqlcipher/src/main/java/net/zetetic/database/DefaultDatabaseErrorHandler.java
+++ b/sqlcipher/src/main/java/net/zetetic/database/DefaultDatabaseErrorHandler.java
@@ -56,7 +56,7 @@ public final class DefaultDatabaseErrorHandler implements DatabaseErrorHandler {
      * @param dbObj the {@link SQLiteDatabase} object representing the database on which corruption
      * is detected.
      */
-    public void onCorruption(SQLiteDatabase dbObj) {
+    public void onCorruption(SQLiteDatabase dbObj, SQLiteException exception) {
         Log.e(TAG, "Corruption reported by sqlite on database: " + dbObj.getPath());
 
 	// If this is a SEE build, do not delete any database files.

--- a/sqlcipher/src/main/java/net/zetetic/database/sqlcipher/SQLiteDatabase.java
+++ b/sqlcipher/src/main/java/net/zetetic/database/sqlcipher/SQLiteDatabase.java
@@ -343,9 +343,9 @@ public final class SQLiteDatabase extends SQLiteClosable implements SupportSQLit
     /**
      * Sends a corruption message to the database error handler.
      */
-    void onCorruption() {
+    void onCorruption(SQLiteException exception) {
         EventLog.writeEvent(EVENT_DB_CORRUPT, getLabel());
-        mErrorHandler.onCorruption(this);
+        mErrorHandler.onCorruption(this, exception);
     }
 
     /**
@@ -1012,7 +1012,7 @@ public final class SQLiteDatabase extends SQLiteClosable implements SupportSQLit
             try {
                 openInner();
             } catch (SQLiteDatabaseCorruptException ex) {
-                onCorruption();
+                onCorruption(ex);
                 openInner();
             }
         } catch (SQLiteException ex) {

--- a/sqlcipher/src/main/java/net/zetetic/database/sqlcipher/SQLiteProgram.java
+++ b/sqlcipher/src/main/java/net/zetetic/database/sqlcipher/SQLiteProgram.java
@@ -21,6 +21,7 @@
 package net.zetetic.database.sqlcipher;
 
 import android.database.DatabaseUtils;
+import android.database.sqlite.SQLiteException;
 import android.os.CancellationSignal;
 
 import androidx.sqlite.db.SupportSQLiteProgram;
@@ -113,8 +114,8 @@ public abstract class SQLiteProgram extends SQLiteClosable implements SupportSQL
     }
 
     /** @hide */
-    protected final void onCorruption() {
-        mDatabase.onCorruption();
+    protected final void onCorruption(SQLiteException exception) {
+        mDatabase.onCorruption(exception);
     }
 
     /**

--- a/sqlcipher/src/main/java/net/zetetic/database/sqlcipher/SQLiteQuery.java
+++ b/sqlcipher/src/main/java/net/zetetic/database/sqlcipher/SQLiteQuery.java
@@ -70,7 +70,7 @@ public final class SQLiteQuery extends SQLiteProgram {
                         mCancellationSignal);
                 return numRows;
             } catch (SQLiteDatabaseCorruptException ex) {
-                onCorruption();
+                onCorruption(ex);
                 throw ex;
             } catch (SQLiteException ex) {
                 Log.e(TAG, "exception: " + ex.getMessage() + "; query: " + getSql());

--- a/sqlcipher/src/main/java/net/zetetic/database/sqlcipher/SQLiteStatement.java
+++ b/sqlcipher/src/main/java/net/zetetic/database/sqlcipher/SQLiteStatement.java
@@ -50,7 +50,7 @@ public final class SQLiteStatement extends SQLiteProgram implements SupportSQLit
         try {
             getSession().executeRaw(getSql(), getBindArgs(), getConnectionFlags(), null);
         } catch (SQLiteDatabaseCorruptException ex) {
-            onCorruption();
+            onCorruption(ex);
             throw ex;
         } finally {
             releaseReference();
@@ -69,7 +69,7 @@ public final class SQLiteStatement extends SQLiteProgram implements SupportSQLit
         try {
             getSession().execute(getSql(), getBindArgs(), getConnectionFlags(), null);
         } catch (SQLiteDatabaseCorruptException ex) {
-            onCorruption();
+            onCorruption(ex);
             throw ex;
         } finally {
             releaseReference();
@@ -90,7 +90,7 @@ public final class SQLiteStatement extends SQLiteProgram implements SupportSQLit
             return getSession().executeForChangedRowCount(
                     getSql(), getBindArgs(), getConnectionFlags(), null);
         } catch (SQLiteDatabaseCorruptException ex) {
-            onCorruption();
+            onCorruption(ex);
             throw ex;
         } finally {
             releaseReference();
@@ -112,7 +112,7 @@ public final class SQLiteStatement extends SQLiteProgram implements SupportSQLit
             return getSession().executeForLastInsertedRowId(
                     getSql(), getBindArgs(), getConnectionFlags(), null);
         } catch (SQLiteDatabaseCorruptException ex) {
-            onCorruption();
+            onCorruption(ex);
             throw ex;
         } finally {
             releaseReference();
@@ -133,7 +133,7 @@ public final class SQLiteStatement extends SQLiteProgram implements SupportSQLit
             return getSession().executeForLong(
                     getSql(), getBindArgs(), getConnectionFlags(), null);
         } catch (SQLiteDatabaseCorruptException ex) {
-            onCorruption();
+            onCorruption(ex);
             throw ex;
         } finally {
             releaseReference();
@@ -154,7 +154,7 @@ public final class SQLiteStatement extends SQLiteProgram implements SupportSQLit
             return getSession().executeForString(
                     getSql(), getBindArgs(), getConnectionFlags(), null);
         } catch (SQLiteDatabaseCorruptException ex) {
-            onCorruption();
+            onCorruption(ex);
             throw ex;
         } finally {
             releaseReference();
@@ -175,7 +175,7 @@ public final class SQLiteStatement extends SQLiteProgram implements SupportSQLit
             return getSession().executeForBlobFileDescriptor(
                     getSql(), getBindArgs(), getConnectionFlags(), null);
         } catch (SQLiteDatabaseCorruptException ex) {
-            onCorruption();
+            onCorruption(ex);
             throw ex;
         } finally {
             releaseReference();


### PR DESCRIPTION
This change allows users to see the `SQLiteException` that triggered a database corruption, giving them more context on what the specific nature of the issue is. This is a breaking change because it changes the signature of the  `DatabaseErrorHandler`, but it should be a trivial one for users to adopt.